### PR TITLE
[Feat] 사용자 추가정보 관련 개선사항 수정 

### DIFF
--- a/src/main/java/com/dndn/backend/dndn/domain/model/enums/AdditionalInformation.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/model/enums/AdditionalInformation.java
@@ -1,6 +1,0 @@
-package com.dndn.backend.dndn.domain.model.enums;
-
-public enum AdditionalInformation {
-    SENIOR,DISABLED,YOUTH,SPECIAL
-    //노년, 장애인,청년, 특수가정,
-}

--- a/src/main/java/com/dndn/backend/dndn/domain/user/api/UserController.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/api/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
 
     @PostMapping
     @Operation(summary = "사용자 등록", description = "사용자의 기본 정보를 등록합니다.")
-    public BaseResponse<UserResponseDTO> createUser(@RequestBody UserRequestDTO dto) {
+    public BaseResponse<UserResponseDTO> createUser(@RequestBody @Valid UserRequestDTO dto) {
         return BaseResponse.onSuccess(
                 SuccessStatus.OK,
                 UserResponseDTO.from(userService.createUser(dto))

--- a/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/Disabled.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/Disabled.java
@@ -28,6 +28,8 @@ public class Disabled {
     @Enumerated(EnumType.STRING)
     private DisabilityType disabilityType;
 
+    private boolean registeredDisabled;
+
     public void registerUser(User user) {
         this.user = user;
     }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/Senior.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/Senior.java
@@ -22,7 +22,7 @@ public class Senior {
 
     private boolean livingWithChildren;
 
-    private boolean houseHolder;
+    private boolean isReceivingBasicPension;
 
     public void registerUser(User user) {
         this.user = user;

--- a/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/User.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.dndn.backend.dndn.domain.user.domain.entity;
 
+import com.dndn.backend.dndn.domain.category.domain.enums.HouseholdType;
+import com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle;
 import com.dndn.backend.dndn.domain.model.entity.BaseEntity;
 import com.dndn.backend.dndn.domain.model.enums.*;
 import com.dndn.backend.dndn.domain.user.dto.UserUpdateRequestDTO;
@@ -10,6 +12,8 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.Date;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -70,10 +74,18 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private EmploymentType employment;
 
-    // 추가 정보
+    // 추가 정보 - 생애주기
+    // (추천로직 참고/조회용(수정x)이므로 연관관계 설정 안했음)
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private AdditionalInformation additionalInformation;
+    private LifeCycle lifeCycle;
+
+    //추가 정보 - 가구 유형 (복수 선택 가능)
+    @Builder.Default
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_household_type", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "household_type")
+    @Enumerated(EnumType.STRING)
+    private Set<HouseholdType> householdTypes = new HashSet<>();
 
     // 노인일 경우
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -106,6 +118,8 @@ public class User extends BaseEntity {
         this.gender = dto.getGender();
         this.family = dto.getFamily();
         this.employment = dto.getEmployment();
+        this.lifeCycle = dto.getLifeCycle();
+        this.householdTypes = dto.getHouseholdTypes();
 
         return this;
     }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/DisabledRequestDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/DisabledRequestDTO.java
@@ -9,4 +9,6 @@ public class DisabledRequestDTO {
     private int disabillityGrade;
 
     private DisabilityType disabilityType;
+
+    private boolean registeredDisabled;
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/DisabledResponseDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/DisabledResponseDTO.java
@@ -13,11 +13,14 @@ public class DisabledResponseDTO {
 
     private DisabilityType disabilityType;
 
+    private boolean registeredDisabled;
+
 
     public static DisabledResponseDTO from(Disabled disabled) {
         return DisabledResponseDTO.builder()
                 .disabillityGrade(disabled.getDisabillityGrade())
                 .disabilityType(disabled.getDisabilityType())
+                .registeredDisabled(disabled.isRegisteredDisabled())
                 .build();
     }
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/SeniorRequestDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/SeniorRequestDTO.java
@@ -7,5 +7,5 @@ public class SeniorRequestDTO {
 
     private boolean livingWithChildren;
 
-    private boolean houseHolder;
+    private boolean isReceivingBasicPension;
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/SeniorResponseDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/SeniorResponseDTO.java
@@ -15,7 +15,7 @@ public class SeniorResponseDTO {
     public static SeniorResponseDTO from(Senior senior) {
         return SeniorResponseDTO.builder()
                 .livingWithChildren(senior.isLivingWithChildren())
-                .houseHolder(senior.isHouseHolder())
+                .houseHolder(senior.isReceivingBasicPension())
                 .build();
     }
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserRequestDTO.java
@@ -1,14 +1,24 @@
 package com.dndn.backend.dndn.domain.user.dto;
 
+import com.dndn.backend.dndn.domain.category.domain.enums.HouseholdType;
+import com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle;
 import com.dndn.backend.dndn.domain.model.enums.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 @Getter
+@NoArgsConstructor
 public class UserRequestDTO {
 
+    @NotBlank
     private String name;
+
     private String phoneNumber;
     private LocalDate birthday;
     private String address;
@@ -18,8 +28,11 @@ public class UserRequestDTO {
     private GenderType gender;
     private FamilyType family;
     private EmploymentType employment;
-    private AdditionalInformation additionalInformation;
 
-    private SeniorRequestDTO seniorInfo;
-    private DisabledRequestDTO disabledInfo;
+    @NotNull
+    private LifeCycle lifeCycle;
+
+    @NotEmpty
+    private Set<HouseholdType> householdTypes;
+
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserResponseDTO.java
@@ -1,12 +1,15 @@
 package com.dndn.backend.dndn.domain.user.dto;
 
 
+import com.dndn.backend.dndn.domain.category.domain.enums.HouseholdType;
+import com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle;
 import com.dndn.backend.dndn.domain.model.enums.*;
 import com.dndn.backend.dndn.domain.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 @Getter
 @Builder
@@ -22,7 +25,8 @@ public class UserResponseDTO {
     private GenderType gender;
     private FamilyType family;
     private EmploymentType employment;
-    private AdditionalInformation additionalInformation;
+    private LifeCycle lifeCycle;
+    private Set<HouseholdType> householdTypes;
 
 
     public static UserResponseDTO from(User user) {
@@ -37,7 +41,8 @@ public class UserResponseDTO {
                 .gender(user.getGender())
                 .family(user.getFamily())
                 .employment(user.getEmployment())
-                .additionalInformation(user.getAdditionalInformation())
+                .lifeCycle(user.getLifeCycle())
+                .householdTypes(user.getHouseholdTypes())
                 .build();
     }
 

--- a/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/dto/UserUpdateRequestDTO.java
@@ -1,15 +1,19 @@
 package com.dndn.backend.dndn.domain.user.dto;
 
+import com.dndn.backend.dndn.domain.category.domain.enums.HouseholdType;
+import com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle;
 import com.dndn.backend.dndn.domain.model.enums.EmploymentType;
 import com.dndn.backend.dndn.domain.model.enums.FamilyType;
 import com.dndn.backend.dndn.domain.model.enums.GenderType;
 import com.dndn.backend.dndn.domain.model.enums.IncomeRange;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -37,4 +41,10 @@ public class UserUpdateRequestDTO {
 
     @NotNull
     private EmploymentType employment;
+
+    @NotNull
+    private LifeCycle lifeCycle;
+
+    @NotEmpty
+    private Set<HouseholdType> householdTypes;
 }

--- a/src/main/java/com/dndn/backend/dndn/domain/user/service/UserService.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/service/UserService.java
@@ -72,7 +72,7 @@ public class UserService {
 
         Senior info = Senior.builder()
                 .livingWithChildren(dto.isLivingWithChildren())
-                .houseHolder(dto.isHouseHolder())
+                .isReceivingBasicPension(dto.isReceivingBasicPension())
                 .build();
 
         user.setSeniorInfo(info); // 연관관계 메서드
@@ -91,6 +91,7 @@ public class UserService {
         Disabled info = Disabled.builder()
                 .disabillityGrade(dto.getDisabillityGrade())
                 .disabilityType(dto.getDisabilityType())
+                .registeredDisabled(dto.isRegisteredDisabled())
                 .build();
 
         user.setDisabledInfo(info); // 연관관계 메서드

--- a/src/main/java/com/dndn/backend/dndn/domain/user/service/UserService.java
+++ b/src/main/java/com/dndn/backend/dndn/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.dndn.backend.dndn.domain.user.service;
 
 
+import com.dndn.backend.dndn.domain.category.domain.enums.HouseholdType;
+import com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle;
 import com.dndn.backend.dndn.domain.model.exception.UserException;
 import com.dndn.backend.dndn.domain.user.domain.entity.Disabled;
 import com.dndn.backend.dndn.domain.user.domain.entity.Senior;
@@ -17,8 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.dndn.backend.dndn.domain.model.enums.AdditionalInformation.DISABLED;
-import static com.dndn.backend.dndn.domain.model.enums.AdditionalInformation.SENIOR;
+import static com.dndn.backend.dndn.domain.category.domain.enums.LifeCycle.SENIOR;
+
 
 @Service
 @Transactional
@@ -30,13 +32,6 @@ public class UserService {
 
     public User createUser(UserRequestDTO dto){
 
-        if (dto.getAdditionalInformation() == SENIOR && dto.getDisabledInfo() != null) {
-            throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
-        }
-
-        if (dto.getAdditionalInformation() == DISABLED && dto.getSeniorInfo() != null) {
-            throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
-        }
 
         User user = User.builder()
                 .name(dto.getName())
@@ -48,8 +43,10 @@ public class UserService {
                 .gender(dto.getGender())
                 .family(dto.getFamily())
                 .employment(dto.getEmployment())
-                .additionalInformation(dto.getAdditionalInformation())
+                .lifeCycle(dto.getLifeCycle())
                 .build();
+
+        user.getHouseholdTypes().addAll(dto.getHouseholdTypes());
 
         userRepository.save(user);
 
@@ -66,7 +63,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus._USER_NOT_FOUND));
 
-        if (user.getAdditionalInformation() != SENIOR) {
+        if (user.getLifeCycle() != SENIOR) {
             throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
         }
 
@@ -84,7 +81,10 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus._USER_NOT_FOUND));
 
-        if (user.getAdditionalInformation() != DISABLED) {
+        boolean isDisabled = user.getHouseholdTypes().stream()
+                .anyMatch(ht -> ht == HouseholdType.DISABLED);
+
+        if (!isDisabled) {
             throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
         }
 
@@ -104,7 +104,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus._USER_NOT_FOUND));
 
-        if (user.getAdditionalInformation() != SENIOR) {
+        if (user.getLifeCycle() != SENIOR) {
             throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
         }
 
@@ -115,7 +115,10 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus._USER_NOT_FOUND));
 
-        if (user.getAdditionalInformation() != DISABLED) {
+        boolean isDisabled = user.getHouseholdTypes().stream()
+                .anyMatch(ht -> ht == HouseholdType.DISABLED);
+
+        if (!isDisabled) {
             throw new UserException(ErrorStatus._INVALID_ADDITIONAL_INFO);
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

- 노인/장애인 추가 질문 수정 
- 추가정보 enum삭제. LifeCycle+HouseHoldType Enum사용. 
- 생애주기/가구유형(가구유형만 여러개) 선택하도록 함
- 생애주기 - 노인 / 가구유형-장애인일시 추가적으로 API 이용해 입력 받도록 함 
